### PR TITLE
chore: adopt exclusion annotions for gosec

### DIFF
--- a/.github/workflows/diff-check-and-lint.yaml
+++ b/.github/workflows/diff-check-and-lint.yaml
@@ -3,6 +3,10 @@ name: Check for diff after manifest and generated targets
 on:
   pull_request: {}
 
+permissions:
+  contents: read
+  pull-requests: write
+   
 jobs:
   diff-check-manifests:
     name: Check for diff

--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -19,7 +19,7 @@ package v1alpha1
 // Ocm credential config key for secrets.
 const (
 	// OCMCredentialConfigKey defines the secret key to look for in case a user provides an ocm credential config.
-	OCMCredentialConfigKey = ".ocmcredentialconfig" //nolint:gosec // it isn't a cred
+	OCMCredentialConfigKey = ".ocmcredentialconfig" // #nosec G101 -- it isn't a credential
 	// OCMConfigKey defines the secret or configmap key to look for in case a user provides an ocm config.
 	OCMConfigKey = ".ocmconfig"
 	// OCMLabelDowngradable defines the secret.

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -236,7 +236,7 @@ func CheckOCMComponent(componentReference, ocmConfigPath string, options ...stri
 	}
 	c = append(c, componentReference)
 
-	cmd := exec.Command(c[0], c[1:]...) //nolint:gosec // The argument list is constructed right above.
+	cmd := exec.Command(c[0], c[1:]...) // #nosec G204 -- The argument list is constructed right above.
 	if _, err := utils.Run(cmd); err != nil {
 		return err
 	}
@@ -255,7 +255,7 @@ func GetOCMResourceImageRef(componentReference, resourceName, ocmConfigPath stri
 	}
 	c = append(c, "get", "resources", componentReference, resourceName, "-oJSON") // -oJSON is used to get the output in JSON format.
 
-	cmd := exec.Command(c[0], c[1:]...) //nolint:gosec // The argument list is constructed right above.
+	cmd := exec.Command(c[0], c[1:]...) // #nosec G204 -- The argument list is constructed right above.
 	output, err := utils.Run(cmd)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
adopt exclusion annotions for gosec
