### PR TITLE
Adjust controller image in kustomization

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -36,7 +36,7 @@ spec:
           # - --leader-elect We dont need it for testing
           - --health-probe-bind-address=:8081
           - --zap-log-level=4
-        image: controller:latest
+        image: ghcr.io/open-component-model/ocm-k8s-toolkit:latest
         name: manager
         imagePullPolicy: Always
         ports:


### PR DESCRIPTION
Since we provide a controller image of `ocm-k8s-toolit` we can adjust the image name in its kustomization.