### PR TITLE
chore: change propagation policy default

### DIFF
--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -29,7 +29,7 @@ type OCMConfiguration struct {
 	// ConfigurationPolicyPropagate other ocm api objects can reference this
 	// object to reuse this configuration.
 	// +kubebuilder:validation:Enum:="Propagate";"DoNotPropagate"
-	// +kubebuilder:default:="DoNotPropagate"
+	// +kubebuilder:default:="Propagate"
 	// +required
 	Policy ConfigurationPolicy `json:"policy,omitempty"`
 }

--- a/config/crd/bases/delivery.ocm.software_components.yaml
+++ b/config/crd/bases/delivery.ocm.software_components.yaml
@@ -89,7 +89,7 @@ spec:
                         acts as LocalObjectReference.
                       type: string
                     policy:
-                      default: DoNotPropagate
+                      default: Propagate
                       description: |-
                         Policy affects the propagation behavior of the configuration. If set to
                         ConfigurationPolicyPropagate other ocm api objects can reference this
@@ -284,7 +284,7 @@ spec:
                         acts as LocalObjectReference.
                       type: string
                     policy:
-                      default: DoNotPropagate
+                      default: Propagate
                       description: |-
                         Policy affects the propagation behavior of the configuration. If set to
                         ConfigurationPolicyPropagate other ocm api objects can reference this

--- a/config/crd/bases/delivery.ocm.software_deployers.yaml
+++ b/config/crd/bases/delivery.ocm.software_deployers.yaml
@@ -64,7 +64,7 @@ spec:
                         acts as LocalObjectReference.
                       type: string
                     policy:
-                      default: DoNotPropagate
+                      default: Propagate
                       description: |-
                         Policy affects the propagation behavior of the configuration. If set to
                         ConfigurationPolicyPropagate other ocm api objects can reference this
@@ -193,7 +193,7 @@ spec:
                         acts as LocalObjectReference.
                       type: string
                     policy:
-                      default: DoNotPropagate
+                      default: Propagate
                       description: |-
                         Policy affects the propagation behavior of the configuration. If set to
                         ConfigurationPolicyPropagate other ocm api objects can reference this

--- a/config/crd/bases/delivery.ocm.software_ocmrepositories.yaml
+++ b/config/crd/bases/delivery.ocm.software_ocmrepositories.yaml
@@ -69,7 +69,7 @@ spec:
                         acts as LocalObjectReference.
                       type: string
                     policy:
-                      default: DoNotPropagate
+                      default: Propagate
                       description: |-
                         Policy affects the propagation behavior of the configuration. If set to
                         ConfigurationPolicyPropagate other ocm api objects can reference this
@@ -195,7 +195,7 @@ spec:
                         acts as LocalObjectReference.
                       type: string
                     policy:
-                      default: DoNotPropagate
+                      default: Propagate
                       description: |-
                         Policy affects the propagation behavior of the configuration. If set to
                         ConfigurationPolicyPropagate other ocm api objects can reference this

--- a/config/crd/bases/delivery.ocm.software_replications.yaml
+++ b/config/crd/bases/delivery.ocm.software_replications.yaml
@@ -82,7 +82,7 @@ spec:
                         acts as LocalObjectReference.
                       type: string
                     policy:
-                      default: DoNotPropagate
+                      default: Propagate
                       description: |-
                         Policy affects the propagation behavior of the configuration. If set to
                         ConfigurationPolicyPropagate other ocm api objects can reference this
@@ -248,7 +248,7 @@ spec:
                         acts as LocalObjectReference.
                       type: string
                     policy:
-                      default: DoNotPropagate
+                      default: Propagate
                       description: |-
                         Policy affects the propagation behavior of the configuration. If set to
                         ConfigurationPolicyPropagate other ocm api objects can reference this

--- a/config/crd/bases/delivery.ocm.software_resources.yaml
+++ b/config/crd/bases/delivery.ocm.software_resources.yaml
@@ -81,7 +81,7 @@ spec:
                         acts as LocalObjectReference.
                       type: string
                     policy:
-                      default: DoNotPropagate
+                      default: Propagate
                       description: |-
                         Policy affects the propagation behavior of the configuration. If set to
                         ConfigurationPolicyPropagate other ocm api objects can reference this
@@ -251,7 +251,7 @@ spec:
                         acts as LocalObjectReference.
                       type: string
                     policy:
-                      default: DoNotPropagate
+                      default: Propagate
                       description: |-
                         Policy affects the propagation behavior of the configuration. If set to
                         ConfigurationPolicyPropagate other ocm api objects can reference this

--- a/internal/controller/component/component_controller_test.go
+++ b/internal/controller/component/component_controller_test.go
@@ -718,7 +718,7 @@ var _ = Describe("Component Controller", func() {
 							Name:       secrets[0].Name,
 							Namespace:  secrets[0].Namespace,
 						},
-						Policy: v1alpha1.ConfigurationPolicyDoNotPropagate,
+						Policy: v1alpha1.ConfigurationPolicyPropagate,
 					},
 					{
 						NamespacedObjectKindReference: meta.NamespacedObjectKindReference{
@@ -745,7 +745,7 @@ var _ = Describe("Component Controller", func() {
 							Name:       configs[0].Name,
 							Namespace:  configs[1].Namespace,
 						},
-						Policy: v1alpha1.ConfigurationPolicyDoNotPropagate,
+						Policy: v1alpha1.ConfigurationPolicyPropagate,
 					},
 					{
 						NamespacedObjectKindReference: meta.NamespacedObjectKindReference{
@@ -842,8 +842,26 @@ var _ = Describe("Component Controller", func() {
 						NamespacedObjectKindReference: meta.NamespacedObjectKindReference{
 							APIVersion: corev1.SchemeGroupVersion.String(),
 							Kind:       "Secret",
+							Name:       secrets[0].Name,
+							Namespace:  secrets[0].Namespace,
+						},
+						Policy: v1alpha1.ConfigurationPolicyDoNotPropagate,
+					},
+					v1alpha1.OCMConfiguration{
+						NamespacedObjectKindReference: meta.NamespacedObjectKindReference{
+							APIVersion: corev1.SchemeGroupVersion.String(),
+							Kind:       "Secret",
 							Name:       secrets[2].Name,
 							Namespace:  secrets[2].Namespace,
+						},
+						Policy: v1alpha1.ConfigurationPolicyDoNotPropagate,
+					},
+					v1alpha1.OCMConfiguration{
+						NamespacedObjectKindReference: meta.NamespacedObjectKindReference{
+							APIVersion: corev1.SchemeGroupVersion.String(),
+							Kind:       "ConfigMap",
+							Name:       configs[0].Name,
+							Namespace:  configs[0].Namespace,
 						},
 						Policy: v1alpha1.ConfigurationPolicyDoNotPropagate,
 					},

--- a/internal/controller/ocmrepository/ocmrepository_controller_test.go
+++ b/internal/controller/ocmrepository/ocmrepository_controller_test.go
@@ -214,7 +214,7 @@ var _ = Describe("OCMRepository Controller", func() {
 							Name:       secrets[0].Name,
 							Namespace:  secrets[0].Namespace,
 						},
-						Policy: v1alpha1.ConfigurationPolicyDoNotPropagate,
+						Policy: v1alpha1.ConfigurationPolicyPropagate,
 					},
 					{
 						NamespacedObjectKindReference: meta.NamespacedObjectKindReference{
@@ -241,7 +241,7 @@ var _ = Describe("OCMRepository Controller", func() {
 							Name:       configs[0].Name,
 							Namespace:  configs[0].Namespace,
 						},
-						Policy: v1alpha1.ConfigurationPolicyDoNotPropagate,
+						Policy: v1alpha1.ConfigurationPolicyPropagate,
 					},
 					{
 						NamespacedObjectKindReference: meta.NamespacedObjectKindReference{


### PR DESCRIPTION
Based on this [discussion](https://github.com/open-component-model/ocm-k8s-toolkit/pull/232#discussion_r2120303722) we will change the propagation policy default to propagate all `ocmConfigs` by default to increase usability.