### PR TITLE
feat: deployer cache

### DIFF
--- a/internal/controller/deployer/cache/digest_object_cache.go
+++ b/internal/controller/deployer/cache/digest_object_cache.go
@@ -1,0 +1,91 @@
+package cache
+
+import (
+	"errors"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/utils/lru"
+)
+
+var (
+	objectCacheSize *prometheus.GaugeVec
+	missCount       *prometheus.CounterVec
+	hitCount        *prometheus.CounterVec
+	evictCount      *prometheus.CounterVec
+)
+
+func MustRegisterMetrics(registerer prometheus.Registerer) {
+	if err := RegisterMetrics(registerer); err != nil {
+		panic(err)
+	}
+}
+
+func RegisterMetrics(registerer prometheus.Registerer) error {
+	return errors.Join(
+		registerer.Register(objectCacheSize),
+	)
+}
+
+func init() {
+	objectCacheSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "cache_size",
+		Help: "number of objects in cache",
+	}, []string{"name"})
+	missCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "cache_miss_total",
+		Help: "number of cache misses",
+	}, []string{"name"})
+	hitCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "cache_hit_total",
+		Help: "number of cache hits",
+	}, []string{"name"})
+}
+
+const DefaultMemoryDigestObjectCacheSize = 1000
+
+type DigestObjectCache[K any, V any] interface {
+	Load(key K, fallback func() (V, error)) (V, error)
+}
+
+func NewMemoryDigestObjectCache[K any, V any](name string, size int, onEvict func(k K, v V)) *MemoryDigestObjectCache[K, V] {
+	return &MemoryDigestObjectCache[K, V]{
+		name: name,
+		cache: lru.NewWithEvictionFunc(size, func(key lru.Key, value interface{}) {
+			objectCacheSize.WithLabelValues(name).Dec()
+			evictCount.WithLabelValues(name).Inc()
+
+			//nolint:forcetypeassert // we know the type is correct because we are the only ones setting it
+			onEvict(key.(K), value.(V))
+		}),
+	}
+}
+
+type MemoryDigestObjectCache[K any, V any] struct {
+	name  string
+	cache *lru.Cache
+}
+
+func (m *MemoryDigestObjectCache[K, V]) Load(key K, fallback func() (V, error)) (V, error) {
+	if m == nil || m.cache == nil {
+		*m = *NewMemoryDigestObjectCache[K, V]("default", DefaultMemoryDigestObjectCacheSize, nil)
+	}
+
+	v, ok := m.cache.Get(key)
+	if ok {
+		hitCount.WithLabelValues(m.name).Inc()
+
+		//nolint:forcetypeassert // we know the type is correct because we are the only ones setting it
+		return v.(V), nil
+	}
+	missCount.WithLabelValues(m.name).Inc()
+	v, err := fallback()
+	if err != nil {
+		return *new(V), err
+	}
+
+	m.cache.Add(key, v)
+	objectCacheSize.WithLabelValues(m.name).Set(float64(m.cache.Len()))
+
+	//nolint:forcetypeassert // we know the type is correct because we just added it
+	return v.(V), nil
+}

--- a/internal/controller/deployer/deployer_controller.go
+++ b/internal/controller/deployer/deployer_controller.go
@@ -222,7 +222,6 @@ func (r *Reconciler) Untrack(ctx context.Context, deployer *deliveryv1alpha1.Dep
 	return nil
 }
 
-//nolint:funlen // we do not want to cut the function at arbitrary points
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, err error) {
 	logger := log.FromContext(ctx)
 	logger.Info("starting reconciliation")

--- a/internal/controller/deployer/deployer_controller.go
+++ b/internal/controller/deployer/deployer_controller.go
@@ -35,6 +35,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	deliveryv1alpha1 "github.com/open-component-model/ocm-k8s-toolkit/api/v1alpha1"
+	"github.com/open-component-model/ocm-k8s-toolkit/internal/controller/deployer/cache"
 	"github.com/open-component-model/ocm-k8s-toolkit/internal/controller/deployer/dynamic"
 	"github.com/open-component-model/ocm-k8s-toolkit/internal/ocm"
 	"github.com/open-component-model/ocm-k8s-toolkit/internal/status"
@@ -67,6 +68,8 @@ type Reconciler struct {
 	// Note that technically we also store tracked objects in the status, but to stay idempotent
 	// we use a tracker so as to only write to the status, and not read from it.
 	resourceWatches func(parent client.Object) []client.Object
+
+	DownloadCache cache.DigestObjectCache[string, []client.Object]
 }
 
 var _ ocm.Reconciler = (*Reconciler)(nil)
@@ -292,67 +295,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 	}
 
 	// Download the resource
-	spec, err := octx.RepositorySpecForConfig(resource.Status.Component.RepositorySpec.Raw, nil)
+	key := resource.Status.Resource.Digest
+
+	objs, err := r.DownloadCache.Load(key, func() ([]client.Object, error) {
+		return r.DownloadResourceWithOCM(ctx, deployer, resource)
+	})
 	if err != nil {
-		status.MarkNotReady(r.EventRecorder, deployer, deliveryv1alpha1.GetComponentVersionFailedReason, err.Error())
-
-		return ctrl.Result{}, fmt.Errorf("failed to get repository spec: %w", err)
-	}
-
-	repo, err := session.LookupRepository(octx, spec)
-	if err != nil {
-		status.MarkNotReady(r.EventRecorder, deployer, deliveryv1alpha1.GetComponentVersionFailedReason, err.Error())
-
-		return ctrl.Result{}, fmt.Errorf("invalid repository spec: %w", err)
-	}
-
-	cv, err := session.LookupComponentVersion(repo, resource.Status.Component.Component, resource.Status.Component.Version)
-	if err != nil {
-		status.MarkNotReady(r.EventRecorder, deployer, deliveryv1alpha1.GetComponentVersionFailedReason, err.Error())
-
-		return ctrl.Result{}, fmt.Errorf("failed to get component version: %w", err)
-	}
-
-	resourceReference := v1.ResourceReference{
-		Resource:      resource.Spec.Resource.ByReference.Resource,
-		ReferencePath: resource.Spec.Resource.ByReference.ReferencePath,
-	}
-
-	resourceAccess, _, err := ocm.GetResourceAccessForComponentVersion(
-		ctx,
-		session,
-		cv,
-		resourceReference,
-		&ocm.Descriptors{List: []*compdesc.ComponentDescriptor{cv.GetDescriptor()}},
-		resolvers.NewCompoundResolver(repo, octx.GetResolver()),
-		resource.Spec.SkipVerify,
-	)
-	if err != nil {
-		status.MarkNotReady(r.EventRecorder, deployer, deliveryv1alpha1.GetOCMResourceFailedReason, err.Error())
-
-		return ctrl.Result{}, fmt.Errorf("failed to get resource access: %w", err)
-	}
-
-	// Get the manifest and its digest. Compare the digest to the one in the resource to make
-	// sure the resource is up to date.
-	manifest, digest, err := r.getResource(cv, resourceAccess)
-	if err != nil {
-		status.MarkNotReady(r.EventRecorder, deployer, deliveryv1alpha1.GetOCMResourceFailedReason, err.Error())
-
-		return ctrl.Result{}, fmt.Errorf("failed to get manifest: %w", err)
-	}
-
-	if resource.Status.Resource.Digest != digest {
-		status.MarkNotReady(r.EventRecorder, deployer, deliveryv1alpha1.GetOCMResourceFailedReason, "resource digest mismatch")
-
-		return ctrl.Result{}, fmt.Errorf("resource digest mismatch: expected %s, got %s", resource.Status.Resource.Digest, digest)
-	}
-
-	objs, err := decodeObjectsFromManifest(manifest)
-	if err != nil {
-		status.MarkNotReady(r.EventRecorder, deployer, deliveryv1alpha1.MarshalFailedReason, err.Error())
-
-		return ctrl.Result{}, fmt.Errorf("failed to decode objects: %w", err)
+		return ctrl.Result{}, fmt.Errorf("failed to download resource from OCM or retrieve it from the cache: %w", err)
 	}
 
 	if err = r.applyConcurrently(ctx, resource, deployer, objs); err != nil {
@@ -373,17 +322,109 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 
 	// TODO: Status propagation of RGD status to deployer
 	//       (see https://github.com/open-component-model/ocm-k8s-toolkit/issues/192)
-	status.MarkReady(r.EventRecorder, deployer, "Applied version %s", resourceAccess.Meta().GetVersion())
+	status.MarkReady(r.EventRecorder, deployer, "Applied version %s", resource.Status.Resource.Version)
 
 	// we requeue the deployer after the requeue time specified in the resource.
 	return ctrl.Result{RequeueAfter: resource.GetRequeueAfter()}, nil
 }
 
-func decodeObjectsFromManifest(manifest io.ReadCloser) (_ []client.Object, err error) {
+func (r *Reconciler) DownloadResourceWithOCM(
+	ctx context.Context,
+	deployer *deliveryv1alpha1.Deployer,
+	resource *deliveryv1alpha1.Resource,
+) (objs []client.Object, err error) {
+	octx := ocmctx.New(datacontext.MODE_EXTENDED)
+	session := ocmctx.NewSession(datacontext.NewSession())
+	defer func() {
+		err = errors.Join(err, octx.Finalize())
+	}()
+
+	// automatically close the session when the ocm context is closed in the above defer
+	octx.Finalizer().Close(session)
+
+	configs, err := ocm.GetEffectiveConfig(ctx, r.GetClient(), deployer)
+	if err != nil {
+		status.MarkNotReady(r.GetEventRecorder(), deployer, deliveryv1alpha1.ConfigureContextFailedReason, err.Error())
+
+		return nil, fmt.Errorf("failed to get effective config: %w", err)
+	}
+
+	err = ocm.ConfigureContext(ctx, octx, r.GetClient(), configs)
+	if err != nil {
+		status.MarkNotReady(r.GetEventRecorder(), deployer, deliveryv1alpha1.ConfigureContextFailedReason, err.Error())
+
+		return nil, fmt.Errorf("failed to configure context: %w", err)
+	}
+
+	spec, err := octx.RepositorySpecForConfig(resource.Status.Component.RepositorySpec.Raw, nil)
+	if err != nil {
+		status.MarkNotReady(r.EventRecorder, deployer, deliveryv1alpha1.GetComponentVersionFailedReason, err.Error())
+
+		return nil, fmt.Errorf("failed to get repository spec: %w", err)
+	}
+
+	repo, err := session.LookupRepository(octx, spec)
+	if err != nil {
+		status.MarkNotReady(r.EventRecorder, deployer, deliveryv1alpha1.GetComponentVersionFailedReason, err.Error())
+
+		return nil, fmt.Errorf("invalid repository spec: %w", err)
+	}
+
+	cv, err := session.LookupComponentVersion(repo, resource.Status.Component.Component, resource.Status.Component.Version)
+	if err != nil {
+		status.MarkNotReady(r.EventRecorder, deployer, deliveryv1alpha1.GetComponentVersionFailedReason, err.Error())
+
+		return nil, fmt.Errorf("failed to get component version: %w", err)
+	}
+
+	resourceReference := v1.ResourceReference{
+		Resource:      resource.Spec.Resource.ByReference.Resource,
+		ReferencePath: resource.Spec.Resource.ByReference.ReferencePath,
+	}
+
+	resourceAccess, _, err := ocm.GetResourceAccessForComponentVersion(
+		ctx,
+		session,
+		cv,
+		resourceReference,
+		&ocm.Descriptors{List: []*compdesc.ComponentDescriptor{cv.GetDescriptor()}},
+		resolvers.NewCompoundResolver(repo, octx.GetResolver()),
+		resource.Spec.SkipVerify,
+	)
+	if err != nil {
+		status.MarkNotReady(r.EventRecorder, deployer, deliveryv1alpha1.GetOCMResourceFailedReason, err.Error())
+
+		return nil, fmt.Errorf("failed to get resource access: %w", err)
+	}
+
+	// Get the manifest and its digest. Compare the digest to the one in the resource to make
+	// sure the resource is up to date.
+	manifest, digest, err := r.getResource(cv, resourceAccess)
+	if err != nil {
+		status.MarkNotReady(r.EventRecorder, deployer, deliveryv1alpha1.GetOCMResourceFailedReason, err.Error())
+
+		return nil, fmt.Errorf("failed to get  manifest: %w", err)
+	}
 	defer func() {
 		err = errors.Join(err, manifest.Close())
 	}()
 
+	if resource.Status.Resource.Digest != digest {
+		status.MarkNotReady(r.EventRecorder, deployer, deliveryv1alpha1.GetOCMResourceFailedReason, "resource digest mismatch")
+
+		return nil, fmt.Errorf("resource digest mismatch: expected %s, got %s", resource.Status.Resource.Digest, digest)
+	}
+
+	if objs, err = decodeObjectsFromManifest(manifest); err != nil {
+		status.MarkNotReady(r.EventRecorder, deployer, deliveryv1alpha1.MarshalFailedReason, err.Error())
+
+		return nil, fmt.Errorf("failed to decode objects: %w", err)
+	}
+
+	return objs, nil
+}
+
+func decodeObjectsFromManifest(manifest io.ReadCloser) (_ []client.Object, err error) {
 	const bufferSize = 4096
 	decoder := yaml.NewYAMLOrJSONDecoder(manifest, bufferSize)
 	var objs []client.Object
@@ -400,10 +441,10 @@ func decodeObjectsFromManifest(manifest io.ReadCloser) (_ []client.Object, err e
 	}
 
 	if len(objs) == 0 {
-		return nil, fmt.Errorf("no objects found in manifest")
+		return nil, fmt.Errorf("no objects found in  manifest")
 	}
 
-	// TODO(jakobmoellerdev): support multiple objects in the manifest once we have pruning
+	// TODO(jakobmoellerdev): support multiple objects in the  manifest once we have pruning
 	if len(objs) > 1 {
 		return nil, fmt.Errorf("multiple objects (%d) found in deployed resource,"+
 			"the current deployer implementation does not officially support this yet", len(objs))
@@ -493,7 +534,10 @@ func (r *Reconciler) applyConcurrently(ctx context.Context, resource *deliveryv1
 
 	for i := range objs {
 		eg.Go(func() error {
-			return r.apply(egctx, resource, deployer, objs[i])
+			//nolint:forcetypeassert // we know that objs[i] is a client.Object because we just cloned it
+			obj := objs[i].DeepCopyObject().(client.Object)
+
+			return r.apply(egctx, resource, deployer, obj)
 		})
 	}
 
@@ -521,7 +565,7 @@ func (r *Reconciler) apply(ctx context.Context, resource *deliveryv1alpha1.Resou
 	return nil
 }
 
-// trackConcurrently tracks the object objects for the deployer concurrently.
+// trackConcurrently tracks the objects for the deployer concurrently.
 //
 // See track for more details on how the objects are tracked.
 func (r *Reconciler) trackConcurrently(ctx context.Context, deployer *deliveryv1alpha1.Deployer, objs []client.Object) error {
@@ -536,7 +580,7 @@ func (r *Reconciler) trackConcurrently(ctx context.Context, deployer *deliveryv1
 	return eg.Wait()
 }
 
-// track registers the object for the deployer.
+// track registers the object for the deployer and tracks it.
 // It checks if the resource watch is already registered and synced. If not, it registers the watch and returns an error
 // indicating that the object is not yet registered and synced.
 // If the resource watch is already registered and synced, it skips the registration and returns nil.

--- a/internal/controller/deployer/suite_test.go
+++ b/internal/controller/deployer/suite_test.go
@@ -11,6 +11,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/open-component-model/ocm-k8s-toolkit/internal/controller/deployer/cache"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
@@ -129,6 +130,9 @@ var _ = BeforeSuite(func() {
 			Scheme:        testEnv.Scheme,
 			EventRecorder: recorder,
 		},
+		DownloadCache: cache.NewMemoryDigestObjectCache[string, []client.Object]("deployer_test_object_cache", 1_000, func(k string, v []client.Object) {
+			GinkgoLogr.Info("DownloadCache eviction", "key", k, "value", fmt.Sprintf("%d objects", len(v)))
+		}),
 	}).SetupWithManager(ctx, k8sManager)).To(Succeed())
 
 	go func() {

--- a/test/e2e/e2e_examples_test.go
+++ b/test/e2e/e2e_examples_test.go
@@ -8,8 +8,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/stretchr/testify/require"
-
 	"github.com/open-component-model/ocm-k8s-toolkit/test/utils"
 )
 
@@ -24,8 +22,6 @@ const (
 
 var _ = Describe("controller", func() {
 	Context("examples", func() {
-		t := GinkgoT()
-
 		for _, example := range examples {
 			fInfo, err := os.Stat(filepath.Join(examplesDir, example.Name()))
 			Expect(err).NotTo(HaveOccurred())
@@ -36,7 +32,6 @@ var _ = Describe("controller", func() {
 			reqFiles := []string{ComponentConstructor, Bootstrap, Rgd, Instance}
 
 			It("should deploy the example "+example.Name(), func() {
-				r := require.New(t)
 
 				By("validating the example directory " + example.Name())
 				var files []string
@@ -53,7 +48,7 @@ var _ = Describe("controller", func() {
 						return nil
 					})).To(Succeed())
 
-				r.Subsetf(files, reqFiles, "required files %s not found in example directory %q", reqFiles, example.Name())
+				Expect(files).To(ContainElements(reqFiles), "required files %s not found in example directory %q", reqFiles, example.Name())
 
 				By("creating and transferring a component version for " + example.Name())
 				// If directory contains a private key, the component version must signed.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

this adds an object cache to the deployer which avoids unnecessary resource downloads on every reconcile

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
follow up from https://github.com/open-component-model/ocm-k8s-toolkit/issues/259 because otherwise reconciles take ages!