### PR TITLE
fix: update podinfo and pin in examples

### DIFF
--- a/docs/getting-started/deploy-helm-chart-bootstrap.md
+++ b/docs/getting-started/deploy-helm-chart-bootstrap.md
@@ -177,13 +177,13 @@ components:
         version: "1.0.0"
         access:
           type: ociArtifact
-          imageReference: ghcr.io/stefanprodan/charts/podinfo:6.7.1
+          imageReference: "ghcr.io/stefanprodan/charts/podinfo:6.9.1@sha256:565d310746f1fa4be7f93ba7965bb393153a2d57a15cfe5befc909b790a73f8a"
       - name: image-resource
         type: ociArtifact
         version: "1.0.0"
         access:
           type: ociRegistry
-          imageReference: ghcr.io/stefanprodan/podinfo:6.7.1
+          imageReference: "ghcr.io/stefanprodan/podinfo:6.9.1@sha256:262578cde928d5c9eba3bce079976444f624c13ed0afb741d90d5423877496cb"
       - name: resource-graph-definition
         type: blob
         version: "1.0.0"
@@ -329,7 +329,7 @@ ocm get componentversion ghcr.io/<your-namespace>//ocm.software/ocm-k8s-toolkit/
 ```text
 # Output is truncated for brevity
 - access:
-    imageReference: ghcr.io/<your-namespace>/stefanprodan/charts/podinfo:6.7.1@sha256:4d5bd3562f0b150bd6cdfdbfb149e7e4ac36e555e25baa1da9f511f4d9fb7391
+    imageReference: ghcr.io/<your-namespace>/stefanprodan/charts/podinfo:6.9.1@sha256:565d310746f1fa4be7f93ba7965bb393153a2d57a15cfe5befc909b790a73f8a
     type: ociArtifact
   digest:
     ...
@@ -338,7 +338,7 @@ ocm get componentversion ghcr.io/<your-namespace>//ocm.software/ocm-k8s-toolkit/
   type: helmChart
   version: 1.0.0
 - access:
-    imageReference: ghcr.io/<your-namespace>/stefanprodan/podinfo:6.7.1@sha256:862ca45e61b32392f7941a1bdfdbe5ff8b6899070135f1bdca1c287d0057fc94
+    imageReference: ghcr.io/<your-namespace>/stefanprodan/podinfo:6.9.1@sha256:262578cde928d5c9eba3bce079976444f624c13ed0afb741d90d5423877496cb
     type: ociArtifact
   digest:
     ...

--- a/docs/getting-started/deploy-helm-chart.md
+++ b/docs/getting-started/deploy-helm-chart.md
@@ -39,7 +39,7 @@ components:
         version: 1.0.0
         access:
           type: ociArtifact
-          imageReference: ghcr.io/stefanprodan/charts/podinfo:6.7.1
+          imageReference: "ghcr.io/stefanprodan/charts/podinfo:6.9.1@sha256:565d310746f1fa4be7f93ba7965bb393153a2d57a15cfe5befc909b790a73f8a"
 ```
 
 After creating the file, we can create the OCM component version:

--- a/examples/helm-configuration-localization/component-constructor.yaml
+++ b/examples/helm-configuration-localization/component-constructor.yaml
@@ -9,13 +9,13 @@ components:
         version: "1.0.0"
         access:
            type: ociArtifact
-           imageReference: ghcr.io/stefanprodan/charts/podinfo:6.7.1
+           imageReference: "ghcr.io/stefanprodan/charts/podinfo:6.9.1@sha256:565d310746f1fa4be7f93ba7965bb393153a2d57a15cfe5befc909b790a73f8a"
       - name: image-resource
         type: ociImage
         version: "1.0.0"
         access:
           type: ociRegistry
-          imageReference: ghcr.io/stefanprodan/podinfo:6.7.1
+          imageReference: "ghcr.io/stefanprodan/podinfo:6.9.1@sha256:262578cde928d5c9eba3bce079976444f624c13ed0afb741d90d5423877496cb"
       - name: kro-rgd
         type: blob
         version: "1.0.0"

--- a/examples/helm-signing/component-constructor.yaml
+++ b/examples/helm-signing/component-constructor.yaml
@@ -9,7 +9,7 @@ components:
         version: "1.0.0"
         access:
            type: ociArtifact
-           imageReference: ghcr.io/stefanprodan/charts/podinfo:6.7.1
+           imageReference: "ghcr.io/stefanprodan/charts/podinfo:6.9.1@sha256:565d310746f1fa4be7f93ba7965bb393153a2d57a15cfe5befc909b790a73f8a"
       - name: kro-rgd
         type: blob
         version: "1.0.0"

--- a/examples/helm-simple/component-constructor.yaml
+++ b/examples/helm-simple/component-constructor.yaml
@@ -9,7 +9,7 @@ components:
         version: "1.0.0"
         access:
            type: ociArtifact
-           imageReference: ghcr.io/stefanprodan/charts/podinfo:6.7.1
+           imageReference: "ghcr.io/stefanprodan/charts/podinfo:6.9.1@sha256:565d310746f1fa4be7f93ba7965bb393153a2d57a15cfe5befc909b790a73f8a"
       - name: kro-rgd
         type: blob
         version: "1.0.0"

--- a/examples/kustomize-configuration-localization/component-constructor.yaml
+++ b/examples/kustomize-configuration-localization/component-constructor.yaml
@@ -12,13 +12,13 @@ components:
           # TODO: Replace this with our own kustomization (Problem: Chicken-Egg problem for testing as the commit is
           #       required).
           repoUrl: https://github.com/stefanprodan/podinfo
-          commit: b3396adb98a6a0f5eeedd1a600beaf5e954a1f28
+          commit: cdd09cdd3daacc3082d5a78062ac493806f7abd0
       - name: image-resource
         type: ociArtifact
         version: "1.0.0"
         access:
           type: ociArtifact
-          imageReference: ghcr.io/stefanprodan/podinfo:6.7.1
+          imageReference: "ghcr.io/stefanprodan/podinfo:6.9.1@sha256:262578cde928d5c9eba3bce079976444f624c13ed0afb741d90d5423877496cb"
       - name: kro-rgd
         type: blob
         version: "1.0.0"

--- a/examples/kustomize-simple/component-constructor.yaml
+++ b/examples/kustomize-simple/component-constructor.yaml
@@ -10,7 +10,7 @@ components:
         access:
           type: gitHub
           repoUrl: https://github.com/stefanprodan/podinfo
-          commit: b3396adb98a6a0f5eeedd1a600beaf5e954a1f28
+          commit: cdd09cdd3daacc3082d5a78062ac493806f7abd0
       - name: kro-rgd
         type: blob
         version: "1.0.0"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

adds missing pins that caused the schema to rely on a missing digest in the OCI access (we could also switch to tags but this is a better pattern anyways)

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

fix https://github.com/open-component-model/ocm-k8s-toolkit/issues/284