### PR TITLE
fix: reduce error severity for unstable and non-normalizeable component version hashes

### DIFF
--- a/internal/controller/component/component_controller.go
+++ b/internal/controller/component/component_controller.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
 	"github.com/fluxcd/pkg/runtime/patch"
 	"github.com/mandelsoft/goutils/sliceutils"
 	"k8s.io/apimachinery/pkg/fields"
@@ -23,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
 	mandelerrors "github.com/mandelsoft/goutils/errors"
 	ocmctx "ocm.software/ocm/api/ocm"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -148,7 +148,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) err
 // +kubebuilder:rbac:groups="",resources=serviceaccounts/token,verbs=create
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
-//nolint:funlen // we do not want to cut the function at arbitrary points
+//nolint:funlen,cyclop // we do not want to cut the function at arbitrary points
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, err error) {
 	logger := log.FromContext(ctx)
 	logger.Info("starting reconciliation")

--- a/internal/ocm/hash.go
+++ b/internal/ocm/hash.go
@@ -18,8 +18,10 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var ErrUnstableHash = errors.New("unstable hash detected")
-var ErrComponentVersionIsNotNormalizeable = errors.New("component version is not normalizeable (possibly due to missing digests on component references or resources")
+var (
+	ErrUnstableHash                       = errors.New("unstable hash detected")
+	ErrComponentVersionIsNotNormalizeable = errors.New("component version is not normalizeable (possibly due to missing digests on component references or resources")
+)
 
 var ErrComponentVersionHashMismatch = errors.New("component version hash mismatch")
 

--- a/internal/ocm/hash.go
+++ b/internal/ocm/hash.go
@@ -18,6 +18,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+var ErrUnstableHash = errors.New("unstable hash detected")
+var ErrComponentVersionIsNotNormalizeable = errors.New("component version is not normalizeable (possibly due to missing digests on component references or resources")
+
 var ErrComponentVersionHashMismatch = errors.New("component version hash mismatch")
 
 // CompareCachedAndLiveHashes compares the normalized hashes of a cached component version
@@ -28,7 +31,8 @@ var ErrComponentVersionHashMismatch = errors.New("component version hash mismatc
 //  2. Computes a normalized hash for both the cached descriptor and the live descriptor
 //     using the specified normalization algorithm and hash function.
 //  3. Compares the two hashes. If they differ, returns ErrComponentVersionHashMismatch.
-//  4. If they match, returns a DigestSpec with the hash metadata.
+//  4. If the component versions are not normalizeable, it collects errors and returns them wrapped in ErrUnstableHash.
+//  5. If they match, returns a DigestSpec with the hash metadata.
 func CompareCachedAndLiveHashes(
 	currentComponentVersion ocmctx.ComponentVersionAccess,
 	liveRepo ocmctx.Repository,
@@ -44,10 +48,12 @@ func CompareCachedAndLiveHashes(
 		err = errors.Join(err, liveCV.Close())
 	}()
 
+	var unstableError error
+
 	// cached version from session
 	cachedDesc := currentComponentVersion.GetDescriptor()
 	if err := cachedDesc.IsNormalizeable(); err != nil {
-		return nil, fmt.Errorf("cached component version is not normalizeable: %w", err)
+		unstableError = errors.Join(unstableError, fmt.Errorf("cached %w: %w", ErrComponentVersionIsNotNormalizeable, err))
 	}
 	cachedHash, err := compdesc.Hash(cachedDesc, normAlgo, hash.New())
 	if err != nil {
@@ -56,7 +62,7 @@ func CompareCachedAndLiveHashes(
 
 	liveDesc := liveCV.GetDescriptor()
 	if err := liveDesc.IsNormalizeable(); err != nil {
-		return nil, fmt.Errorf("live component version is not normalizeable: %w", err)
+		unstableError = errors.Join(unstableError, fmt.Errorf("live %w: %w", ErrComponentVersionIsNotNormalizeable, err))
 	}
 	liveHash, err := compdesc.Hash(liveDesc, normAlgo, hash.New())
 	if err != nil {
@@ -67,11 +73,15 @@ func CompareCachedAndLiveHashes(
 		return nil, fmt.Errorf("%w: %s != %s", ErrComponentVersionHashMismatch, hash, liveHash)
 	}
 
+	if unstableError != nil {
+		err = fmt.Errorf("%w: %w", ErrUnstableHash, unstableError)
+	}
+
 	return &ocmv1.DigestSpec{
 		HashAlgorithm:          hash.String(),
 		NormalisationAlgorithm: normAlgo,
 		Value:                  cachedHash,
-	}, nil
+	}, err
 }
 
 // GetObjectDataHash returns a stable 64-hex digest for a set of objects.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Logs an info-level event for unstable hashes without failing reconciliation.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

If a component is referenced that does NOT contain a digest (allowed per OCM Spec), we now just log an info event to the component instead of failing out the component status:

```
component:
  componentReferences:
  - componentName: foo.io/bar
    name: my-unsafe-component
    version: 0.0.1
```